### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Dash CUI client.
 
 ## install
 ```
-npm -g intall dash-cli
+npm -g install dash-cli
 ```
 
 ## usage


### PR DESCRIPTION
`intall` => `install`
